### PR TITLE
Optimal `ExpressionHelper.GetValue()` performance

### DIFF
--- a/src/MicroOrm.Dapper.Repositories/Extensions/CollectionExtensions.cs
+++ b/src/MicroOrm.Dapper.Repositories/Extensions/CollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace MicroOrm.Dapper.Repositories.Extensions
 {

--- a/src/MicroOrm.Dapper.Repositories/Extensions/TypeExtensions.cs
+++ b/src/MicroOrm.Dapper.Repositories/Extensions/TypeExtensions.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
+
 using MicroOrm.Dapper.Repositories.Attributes;
 using MicroOrm.Dapper.Repositories.SqlGenerator;
 
@@ -51,6 +52,7 @@ namespace MicroOrm.Dapper.Repositories.Extensions
 
             return propertyInfos;
         }
+
         public static SqlPropertyMetadata[] FindClassMetaDataProperties(this Type objectType)
         {
             if (_metaDataPropertyCache.TryGetValue(objectType, out var cachedEntry))
@@ -70,5 +72,7 @@ namespace MicroOrm.Dapper.Repositories.Extensions
 
             return propertyInfos;
         }
+
+        public static Type UnwrapNullableType(this Type type) => Nullable.GetUnderlyingType(type) ?? type;
     }
 }

--- a/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
+++ b/test/MicroOrm.Dapper.Repositories.Tests/SqlGeneratorTests/MsSqlGeneratorTests.cs
@@ -125,6 +125,23 @@ namespace MicroOrm.Dapper.Repositories.Tests.SqlGeneratorTests
         }
 
         [Fact]
+        public static void ExpressionNullablePerformance()
+        {
+            ISqlGenerator<User> userSqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+
+            var i = 0;
+            var today = DateTime.Now.Date;
+            var tomorrow = today.AddDays(1);
+            while (i++ < 10)
+            {
+                userSqlGenerator.GetSelectAll(x => x.UpdatedAt >= today, null);
+                userSqlGenerator.GetSelectAll(x => x.UpdatedAt < tomorrow, null);
+                userSqlGenerator.GetSelectAll(x => x.UpdatedAt >= today && x.UpdatedAt < tomorrow, null);
+            }
+            Assert.False(false, "dual ExpressionNullablePerformance");
+        }
+
+        [Fact]
         public static void BoolFalseEqualNotPredicate()
         {
             ISqlGenerator<Phone> userSqlGenerator = new SqlGenerator<Phone>(_sqlConnector, true);


### PR DESCRIPTION
Optimal `ExpressionHelper.GetValue()` performance
Reduce consumption of 'nullable type Convert' calls to 'Lambda.Compile()'

FROM: https://github.com/dotnet/efcore/blob/master/src/EFCore/Query/Internal/ParameterExtractingExpressionVisitor.cs#L370
